### PR TITLE
Fix module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.evy.dev/pratt
+module github.com/gozeloglu/pratt
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	_ "embed"
 	"flag"
 	"fmt"
-	evyStr "go.evy.dev/pratt/internal/string"
+	evyStr "github.com/gozeloglu/pratt/internal/string"
 )
 
 func main() {


### PR DESCRIPTION
* `go.evy.dev/pratt` → `github.com/gozeloglu/pratt`